### PR TITLE
Use QGIS LTR in Docker container

### DIFF
--- a/qgis/Dockerfile
+++ b/qgis/Dockerfile
@@ -1,10 +1,42 @@
-FROM geocompr/geocompr
-ENV DEBIAN_FRONTEND noninteractive
-# source: https://qgis.org/en/site/forusers/alldownloads.html#debian-ubuntu
-RUN apt update
-RUN apt -y install software-properties-common
-RUN apt -y install qgis qgis-plugin-grass saga
-# run QGIS in a headless state
+FROM ghcr.io/geocompx/docker:latest
+# ARG only sets the ENV var during the build session whereas ENV also keeps it in the containers later on
+ARG DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get -y --with-new-pkgs upgrade
+# how to install LTR, latest or nightly QGIS version, see:
+# https://qgis.org/en/site/forusers/alldownloads.html#debian-ubuntu
+RUN apt-get -y install gnupg software-properties-common python3-pip
+RUN add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+RUN wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+# here, we install the QGIS-LTR, if you like the latest one, change in URIs from ubuntugis-ltr to ubuntugis
+SHELL ["/bin/bash", "-c"]
+RUN echo $'Types: deb deb-src \n\
+URIs: https://qgis.org/ubuntugis-ltr\n\
+Suites: jammy\n\
+Architectures: amd64\n\
+Components: main\n\
+Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg' >/etc/apt/sources.list.d/qgis.sources
+RUN apt-get update
+# here using apt-get leads 10 packages kept back which in turn prevents the successful installation of qgis, ok, use --with-new-pkgs!
+RUN apt-get -y --with-new-pkgs upgrade && \
+  apt-get -y autoremove && \
+  apt-get -y install qgis qgis-plugin-grass saga
+
+# for how to use the qgis-plugin-manager, see https://github.com/3liz/qgis-plugin-manager
+RUN pip3 install qgis-plugin-manager
+# to enable the qgis-plugin-manager, add the corresponding path to PATH
+ENV PATH="/home/rstudio/.local/bin:$PATH"
+RUN mkdir -p /home/rstudio/.local/share/QGIS/QGIS3/profiles/default/python/plugins
+ENV QGIS_PLUGINPATH=/home/rstudio/.local/share/QGIS/QGIS3/profiles/default/python/plugins
+RUN qgis-plugin-manager init
+RUN qgis-plugin-manager update
+# install SAGA next generation plugin
+RUN qgis-plugin-manager install 'Processing Saga NextGen Provider'
+# RUN qgis_process in a headless state
 ENV QT_QPA_PLATFORM=offscreen
+# enable desired plugins
+RUN qgis_process plugins enable processing_saga_nextgen
+RUN qgis_process plugins enable grassprovider
+
 # install R package qgisprocess from Github (paused due to API limits)
-RUN R -e "remotes::install_github('r-spatial/qgisprocess')"
+RUN Rscript -e "remotes::install_github('r-spatial/qgisprocess')"


### PR DESCRIPTION
Hey Robin,
in accordance with the discussion in https://github.com/r-spatial/qgisprocess/pull/134, I propose to use the QGIS LTR in our qgis docker container. Addionally, I download the SAGA next generation plugin with which it is possible to use the latest SAGA versions. This is necessary, since the old sagaprovider (supporting SAGA 2.3) will no longer be supported starting with QGIS 3.30.

Pls note that it probably would make sense to base all our Dockerfiles on ghcr.io/geocompx/geocompr. The QGIS dockerfile still downloaded the image from geocompr/geocompr.