### PR TITLE
fix: improve Quarto devcontainer support and refresh Quarto pins

### DIFF
--- a/dockerfiles/conda/Dockerfile
+++ b/dockerfiles/conda/Dockerfile
@@ -1,5 +1,7 @@
 FROM continuumio/miniconda3
 
+ARG QUARTO_VERSION=1.9.37
+
 # See https://pythonspeed.com/articles/conda-docker-image-size/
 # RUN environment.yml .
 RUN wget https://github.com/geocompr/py/raw/main/environment.yml
@@ -16,8 +18,12 @@ RUN . /root/.bashrc && \
 RUN echo "conda activate geocompy" >> ~/.bashrc
 SHELL ["/bin/bash", "--login", "-c"]
 
-RUN wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.34/quarto-1.7.34-linux-amd64.deb
-RUN dpkg -i quarto*
+RUN arch="$(dpkg --print-architecture)" \
+    && wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${arch}.deb" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends "./quarto-${QUARTO_VERSION}-linux-${arch}.deb" \
+    && rm "quarto-${QUARTO_VERSION}-linux-${arch}.deb" \
+    && rm -rf /var/lib/apt/lists/*
 
 # RUN wget https://github.com/geocompr/py/archive/refs/heads/main.zip
 # RUN unzip main.zip

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,7 +1,15 @@
-FROM rocker/geospatial:latest
-RUN R -e "remotes::install_github('geocompx/geocompkg', upgrade = TRUE)"
+ARG ROCKER_GEOSPATIAL_IMAGE=rocker/geospatial:latest
+FROM ${ROCKER_GEOSPATIAL_IMAGE}
+
+ARG QUARTO_VERSION=1.9.37
+
+# Ship editor defaults with the image so downstream Codespaces/devcontainers
+# inherit Quarto support even when they only reference the published image.
+LABEL devcontainer.metadata='[{"customizations":{"vscode":{"extensions":["quarto.quarto","REditorSupport.r","ms-python.python","ms-toolsai.jupyter"]}}}]'
+
+RUN R -e "install.packages('remotes', repos = 'https://cloud.r-project.org/'); remotes::install_github('geocompx/geocompkg', upgrade = TRUE)"
 # Update quarto to latest stable version:
-RUN /rocker_scripts/install_quarto.sh 1.7.34
+RUN /rocker_scripts/install_quarto.sh ${QUARTO_VERSION}
 # Set RStudio preferences
 # No inline code:
 RUN echo '{' >> /etc/rstudio/rstudio-prefs.json

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,12 +1,18 @@
-FROM python:3.12-slim-bookworm
+ARG PYTHON_BASE_IMAGE=python:3.12-slim-bookworm
+FROM ${PYTHON_BASE_IMAGE}
+
+ARG QUARTO_VERSION=1.9.37
+
+LABEL devcontainer.metadata='[{"customizations":{"vscode":{"extensions":["quarto.quarto","REditorSupport.r","ms-python.python","ms-toolsai.jupyter"]}}}]'
 
 # Install dependencies, git, and gh cli
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget \
-    unzip \
-    git \
+    ca-certificates \
     build-essential \
     curl \
+    git \
+    unzip \
+    wget \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
@@ -15,13 +21,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install quarto
-RUN wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.7.34/quarto-1.7.34-linux-amd64.deb
-RUN dpkg -i quarto*
-RUN rm quarto*
+RUN arch="$(dpkg --print-architecture)" \
+    && wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-${arch}.deb" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends "./quarto-${QUARTO_VERSION}-linux-${arch}.deb" \
+    && rm "quarto-${QUARTO_VERSION}-linux-${arch}.deb" \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install requirements
-RUN wget https://raw.githubusercontent.com/geocompx/py/main/requirements.txt
-RUN pip install -r requirements.txt
+RUN wget -q -O /tmp/requirements.txt https://raw.githubusercontent.com/geocompx/py/main/requirements.txt \
+    && python -m pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
 
 # Clean up build tools to reduce image size (optional but recommended)
 RUN apt purge -y build-essential && apt autoremove -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add devcontainer image metadata so downstream Codespaces/devcontainers inherit the Quarto, R, Python, and Jupyter VS Code extensions
- update the shared Quarto pins to 1.9.37 and make the Debian installs architecture-aware
- fix the minimal image build by reinstalling emotes before install_github()

## Diagnosis
The missing .qmd syntax highlighting looks upstreamable at the image layer rather than in Quarto itself:
- itsleeds/tds already requests quarto.quarto in .devcontainer/devcontainer.json
- the Quarto VS Code extension contributes .qmd grammars statically and supports both workspace and web, so if highlighting is absent the more likely failure mode is that the extension is not reliably present in the resulting Codespace
- shipping devcontainer.metadata with the published images makes the Quarto editor support travel with the image, which helps downstream repos that consume ghcr.io/geocompx/* from Codespaces/devcontainers

## Notes
- I tried bumping the Python base to 3.13 as part of the refresh, but the current geocompy requirements do not build cleanly there yet, so this keeps the Python image on 3.12 for now while still updating Quarto and the editor metadata.
- Rocker's current geospatial:latest base is still Ubuntu 24.04, so I left that base unchanged and made it configurable for a future Rocker-side Ubuntu bump.