### PR TITLE
devcontainer: enable bracketed paste in VS Code R settings for arf

### DIFF
--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -5,7 +5,7 @@ ARG QUARTO_VERSION=1.9.37
 
 # Ship editor defaults with the image so downstream Codespaces/devcontainers
 # inherit Quarto support even when they only reference the published image.
-LABEL devcontainer.metadata='[{"customizations":{"vscode":{"extensions":["quarto.quarto","REditorSupport.r","ms-python.python","ms-toolsai.jupyter"]}}}]'
+LABEL devcontainer.metadata='[{"customizations":{"vscode":{"settings":{"r.rterm.linux":"/usr/local/bin/arf","r.bracketedPaste":true},"extensions":["quarto.quarto","REditorSupport.r","ms-python.python","ms-toolsai.jupyter"]}}}]'
 
 RUN R -e "if (!requireNamespace('pak', quietly = TRUE)) install.packages('pak', repos = 'https://cloud.r-project.org/'); pak::pak('geocompx/geocompkg', upgrade = TRUE)"
 # Install arf — Alternative R Frontend (https://github.com/eitsupi/arf)

--- a/osgeo/Dockerfile
+++ b/osgeo/Dockerfile
@@ -6,6 +6,10 @@ RUN export ARF_CONSOLE_INSTALL_DIR=/usr/local ARF_CONSOLE_NO_MODIFY_PATH=1 \
     && sh /tmp/arf-installer.sh \
     && rm /tmp/arf-installer.sh
 
+# Ship editor defaults with the image so downstream Codespaces/devcontainers
+# inherit VS Code R support even when they only reference the published image.
+LABEL devcontainer.metadata='[{"customizations":{"vscode":{"settings":{"r.rterm.linux":"/usr/local/bin/arf","r.bracketedPaste":true},"extensions":["quarto.quarto","REditorSupport.r","ms-python.python","ms-toolsai.jupyter"]}}}]'
+
 # Set RStudio preferences
 # No inline code:
 RUN echo '{' >> /etc/rstudio/rstudio-prefs.json

--- a/pythonr/Dockerfile
+++ b/pythonr/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/geocompx/python
 
-LABEL devcontainer.metadata='[{"customizations":{"vscode":{"settings":{"r.rterm.linux":"/usr/local/bin/arf"},"extensions":["quarto.quarto","REditorSupport.r","ms-python.python","ms-toolsai.jupyter"]}}}]'
+LABEL devcontainer.metadata='[{"customizations":{"vscode":{"settings":{"r.rterm.linux":"/usr/local/bin/arf","r.bracketedPaste":true},"extensions":["quarto.quarto","REditorSupport.r","ms-python.python","ms-toolsai.jupyter"]}}}]'
 
 # Note: previously this image built on Rocker but install_R_ppa.sh fails on Debian 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Enable `r.bracketedPaste: true` in the `devcontainer.metadata` label shipped with every image that bundles arf (Alternative R Frontend).

**Why:** Without bracketed paste, `vscode-R` sends multiline R code as individual keystrokes. arf's auto-match feature then interprets continuation lines as separate commands, causing errors like:

```
Error: unexpected "," in "  c(xmin = -3.1, ymin = 42.8, ..."
```

See https://github.com/eitsupi/arf/issues/212 for the full bug report.

**Changes:**

| Image | Before | After |
|-------|--------|-------|
| `pythonr/` | `r.rterm.linux` only | adds `r.bracketedPaste: true` |
| `minimal/` | extensions only (no R settings) | adds both `r.rterm.linux` and `r.bracketedPaste` -- propagates to rocker-rpy, rocker-rpyjl, suggests, rust, and root |
| `osgeo/` | no devcontainer metadata at all | adds full block with both R settings + extensions |

**Related issues:**
- https://github.com/REditorSupport/vscode-R/issues/1590 -- bracketed paste not working on Windows (upstream)
- https://github.com/eitsupi/arf/issues/212 -- multiline code chunks fail without bracketed paste
