### PR TITLE
Add geospatial Julia packages to rocker-rpyjl

### DIFF
--- a/rocker-rpyjl/Dockerfile
+++ b/rocker-rpyjl/Dockerfile
@@ -1,3 +1,4 @@
 FROM ghcr.io/geocompx/rocker-rpy
 RUN /rocker_scripts/install_julia.sh
 RUN R -e "install.packages('JuliaCall')"
+RUN julia -e 'using Pkg; Pkg.add(["GeoInterface", "GeoFormatTypes", "Extents", "GeometryOps", "LibGEOS", "ArchGDAL", "GeoDataFrames", "Shapefile", "GeoJSON", "GeoParquet", "Rasters", "NCDatasets", "ZarrDatasets", "GRIBDatasets", "DataFrames", "CSV", "Plots", "Makie", "CairoMakie"])'


### PR DESCRIPTION
Resurrects #74, which was closed as stale.

Adds the core JuliaGeo ecosystem packages to the `rocker-rpyjl` image so the Julia side ships with geospatial support out of the box:

`GeoDataFrames`, `Shapefile`, `GeoJSON`, `GeoParquet`, `LibGEOS`, `ArchGDAL`, `GeometryOps`, `GeoInterface`, `Rasters`, `NCDatasets`, `ZarrDatasets`, `GRIBDatasets`.

Rebased on current `master`: the image path is already `ghcr.io/geocompx/rocker-rpy` here, so this PR only adds the `julia ... Pkg.add(...)` step on top of the existing `JuliaCall` install — addressing the stale-image-path concern raised on #74.